### PR TITLE
Fix pkg_config sdl2 string

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -16,6 +16,7 @@ defmodule Membrane.SDL.BundlexProject do
           sdl2: [
             {:precompiled, Membrane.PrecompiledDependencyProvider.get_dependency_url(:sdl2),
              "SDL2"},
+            {:pkg_config, "SDL2"},
             {:pkg_config, "sdl2"}
           ]
         ],

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -16,7 +16,7 @@ defmodule Membrane.SDL.BundlexProject do
           sdl2: [
             {:precompiled, Membrane.PrecompiledDependencyProvider.get_dependency_url(:sdl2),
              "SDL2"},
-            {:pkg_config, "SDL2"}
+            {:pkg_config, "sdl2"}
           ]
         ],
         preprocessor: Unifex


### PR DESCRIPTION
Needed to make this change for it to compile after disabling precompiled dependency.